### PR TITLE
Fix an issue where only the first space in a query would be replaced

### DIFF
--- a/js/wee.js
+++ b/js/wee.js
@@ -1117,7 +1117,7 @@ var Wee;
 						.split('&').forEach(function(el) {
 							var split = el.split('='),
 								key = split[0],
-								val = split[1].replace('+', ' ') || '';
+								val = split[1].replace(/\+/g, ' ') || '';
 
 							if (obj[key]) {
 								obj[key] = W.$toArray(obj[key]);


### PR DESCRIPTION
This commit corrects an issue where only the first instance of a space would be replaced. Using RegEx with a `global` flag processes the entire string as intended.
