### PR TITLE
Update wrap mixin add white-space mixin

### DIFF
--- a/css/wee.mixins.less
+++ b/css/wee.mixins.less
@@ -2313,9 +2313,6 @@
 .wrap () {
 	white-space: normal;
 }
-.white-space (@value) {
-	white-space: @value;
-}
 .ellipsis (@maxWidth: false) {
 	overflow-x: hidden;
 	text-overflow: ellipsis;

--- a/css/wee.mixins.less
+++ b/css/wee.mixins.less
@@ -2311,7 +2311,10 @@
 	white-space: nowrap;
 }
 .wrap () {
-	white-space: initial;
+	white-space: normal;
+}
+.white-space (@value) {
+	white-space: @value;
 }
 .ellipsis (@maxWidth: false) {
 	overflow-x: hidden;


### PR DESCRIPTION
.wrap() mixin was defaulting its value to initial which is not supported in ie, changing it to normal allows it to work  across all major browsers.

Add white-space mixin to accept any available white-space value.
