### PR TITLE
Add view.hasHelper method to check for existing helpers

### DIFF
--- a/js/wee.view.js
+++ b/js/wee.view.js
@@ -577,6 +577,15 @@
 		},
 
 		/**
+		 * Check for the existence of a named helper
+		 *
+		 * @param {string} name
+		 */
+		hasHelper: function(name) {
+			return typeof helpers[name] !== 'undefined';
+		},
+
+		/**
 		 * Add views to store for on-demand reference
 		 *
 		 * @param {object|string} name

--- a/js/wee.view.js
+++ b/js/wee.view.js
@@ -580,6 +580,7 @@
 		 * Check for the existence of a named helper
 		 *
 		 * @param {string} name
+		 * @returns {boolean}
 		 */
 		hasHelper: function(name) {
 			return typeof helpers[name] !== 'undefined';


### PR DESCRIPTION
Primary use is to be able to see if a helper exists before calling addHelper. Ie:

```javascript
if (! Wee.view.hasHelper('myNewHelper') {
	Wee.view.addHelper('myNewHelper', function() {...});
}
```