### PR TITLE
Update wee.mixins.less

### DIFF
--- a/css/wee.mixins.less
+++ b/css/wee.mixins.less
@@ -205,7 +205,7 @@
 .background-gradient (@color: @gray; @start: rgba(0, 0, 0, .8); @end: rgba(0, 0, 0, .2); @angle: 180) when (iscolor(@color)) and (iscolor(@start)) {
 	@deg: unit(@angle, deg);
 	@revDeg: unit(mod((450 - @angle), 360), deg);
-	background-color: @start;
+	background-color: @color;
 	background: -webkit-linear-gradient(@revDeg, @start, @end);
 	background: linear-gradient(@deg, @start, @end);
 }


### PR DESCRIPTION
.background-gradient() [https://github.com/weepower/wee-core/blob/66d0a5ddfffbb7751bdfbce409850f11f5529d8d/css/wee.mixins.less#L205]

The `background-color` fallback property was updated to reflect intended usage where you can pass a fallback color. Old version used `@start` instead.