### PR TITLE
Change reset.scss `if` statement for $minWidth

### DIFF
--- a/styles/reset.scss
+++ b/styles/reset.scss
@@ -5,7 +5,7 @@
 	padding: 0;
 	box-sizing: border-box;
 }
-@if ($minWidth != 0 or $minWidth != false) {
+@if ($minWidth != 0 and $minWidth != false) {
 	html,
 	body {
 		min-width: $minWidth;


### PR DESCRIPTION
The loose `or` statement allowed the default `false` into the mixin as the value of `min-width`. This happens because originally the test `$minWidth != 0 and $minWidth != false` is always true if no change is made to the default value of `$minWidth` (set to false).