### PR TITLE
Add reset.scss to $figureBorderColor conditional

### DIFF
--- a/styles/reset.scss
+++ b/styles/reset.scss
@@ -74,7 +74,11 @@ figure {
 		@include rounded($defaultRadius);
 	}
 
-	border: 1px solid $figureBorderColor;
+	@if ($figureBorderColor != false) {
+		border: 1px solid $figureBorderColor;
+	} @else {
+		border: none;
+	}
 	padding: $figurePadding;
 	position: relative;
 	text-align: center;


### PR DESCRIPTION
$figureBorderColor prints `false` by default when no color is set. Fixes the border rule to make sense with this logic.