### PR TITLE
Add $removeStyle to wee dom

### DIFF
--- a/scripts/dom/index.js
+++ b/scripts/dom/index.js
@@ -1045,6 +1045,20 @@ export function $removeClass(target, value) {
 }
 
 /**
+ * Remove specified style property of each matching selection
+ *
+ * @param {($|HTMLElement|string)} target
+ * @param {string} name
+ */
+export function $removeStyle(target, name) {
+	$each(target, el => {
+		name.split(/\s+/).forEach(value => {
+			el.style.removeProperty(value);
+		});
+	});
+}
+
+/**
  * Replace each matching selection with selection or markup
  *
  * @param {($|HTMLElement|string)} target

--- a/scripts/wee-dom.js
+++ b/scripts/wee-dom.js
@@ -463,6 +463,18 @@ $chain({
 	},
 
 	/**
+	 * Remove specified style property of each matching selection
+	 *
+	 * @param {string} name
+	 * @returns {$}
+	 */
+	removeStyle(name) {
+		W.$removeStyle(this, name);
+
+		return this;
+	},
+
+	/**
 	 * Replace each matching selection with selection or markup
 	 *
 	 * @param {($|HTMLElement|string)} source

--- a/tests/scripts/unit/wee-dom.js
+++ b/tests/scripts/unit/wee-dom.js
@@ -941,6 +941,16 @@ describe('DOM', () => {
 		});
 	});
 
+	describe('$removeStyle', () => {
+		before(createSingleDiv);
+		after(resetDOM);
+		it('should remove specified style property from selection', () => {
+			$('.test').removeStyle('height');
+
+			expect($('.test')[0].style.height).to.equal("");
+		});
+	});
+
 	describe('$replaceWith', () => {
 		before(createMultiDiv);
 		before(createSingleDiv);


### PR DESCRIPTION
Allows removal of specific style properties without removing style attribute.

```js
$(el).removeStyle('height');
```